### PR TITLE
container: rework this container to support Zephyr builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # [1] https://optee.readthedocs.io/en/latest/building/devices/qemu.html#qemu-v8
 
 FROM ubuntu as gcc-builder
-MAINTAINER Jerome Forissier <jerome@forissier.org>
+MAINTAINER Volodymyr Babchuk <volodymyr_babchuk@epam.com>
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update \
@@ -23,6 +23,7 @@ RUN apt update \
   libtool \
   libtool-bin \
   python3-dev \
+  python3-setuptools \
   texinfo \
   unzip \
   wget
@@ -45,11 +46,46 @@ RUN git clone https://github.com/crosstool-ng/crosstool-ng \
  && echo 'CT_CC_GCC_CORE_EXTRA_CONFIG_ARRAY="--enable-standard-branch-protection"' >>.config \
  && ./ct-ng build.$(nproc)
 
+ARG ZEPHYR_SDK_VER="0.16.8"
+
+RUN wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v${ZEPHYR_SDK_VER}/zephyr-sdk-${ZEPHYR_SDK_VER}_linux-x86_64.tar.xz && \
+  tar xvf zephyr-sdk-${ZEPHYR_SDK_VER}_linux-x86_64.tar.xz && \
+  rm zephyr-sdk-${ZEPHYR_SDK_VER}_linux-x86_64.tar.xz && \
+  cd zephyr-sdk-${ZEPHYR_SDK_VER}/ && \
+  rm -rf arc-zephyr-elf \
+	arc64-zephyr-elf \
+	arm-zephyr-eabi \
+	microblazeel-zephyr-elf \
+	mips-zephyr-elf \
+	nios2-zephyr-elf \
+	riscv64-zephyr-elf \
+	sparc-zephyr-elf \
+	x86_64-zephyr-elf \
+	xtensa-dc233c_zephyr-elf \
+	xtensa-espressif_esp32_zephyr-elf \
+	xtensa-espressif_esp32s2_zephyr-elf \
+	xtensa-espressif_esp32s3_zephyr-elf \
+	xtensa-intel_ace15_mtpm_zephyr-elf \
+	xtensa-intel_tgl_adsp_zephyr-elf \
+	xtensa-mtk_mt8195_adsp_zephyr-elf \
+	xtensa-nxp_imx8m_adsp_zephyr-elf \
+	xtensa-nxp_imx8ulp_adsp_zephyr-elf \
+	xtensa-nxp_imx_adsp_zephyr-elf \
+	xtensa-nxp_rt500_adsp_zephyr-elf \
+	xtensa-nxp_rt600_adsp_zephyr-elf \
+	xtensa-sample_controller_zephyr-elf
+
 FROM ubuntu:22.04
-MAINTAINER Jerome Forissier <jerome.forissier@linaro.org>
+MAINTAINER Volodymyr Babchuk <volodymyr_babchuk@epam.com>
 
 RUN mkdir -p /usr/local
 COPY --from=gcc-builder /home/nonroot/x-tools/aarch64-unknown-linux-uclibc /usr/local/
+
+RUN apt-get update \
+ && apt-get install -y wget
+
+RUN wget https://apt.kitware.com/kitware-archive.sh \
+ && bash  kitware-archive.sh
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
@@ -95,14 +131,22 @@ RUN apt-get update \
   python3-pycryptodome \
   python3-pyelftools \
   python3-venv \
+  python3-pip \
   rsync \
   sudo \
   unzip \
   uuid-dev \
   vim \
   xz-utils \
-  wget \
  && apt-get autoremove
+
+RUN pip3 install west
+
+ARG ZEPHYR_SDK_VER="0.16.8"
+COPY --from=gcc-builder /home/nonroot/zephyr-sdk-${ZEPHYR_SDK_VER} /opt/
+
+RUN cd /opt \
+ && ./setup.sh -h -c -t aarch64-zephyr-elf
 
 RUN curl -o /usr/local/bin/repo https://storage.googleapis.com/git-repo-downloads/repo \
  && chmod a+x /usr/local/bin/repo \
@@ -110,8 +154,8 @@ RUN curl -o /usr/local/bin/repo https://storage.googleapis.com/git-repo-download
  && git config --global user.email "ci@invalid"
 
 COPY get_optee_qemuv8.sh /root
-COPY get_optee.sh /root
+COPY get_zephyr.sh /root
 
 RUN chmod +rx /root
 RUN chmod +x /root/get_optee_qemuv8.sh
-RUN chmod +x /root/get_optee.sh
+RUN chmod +x /root/get_zephyr.sh

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
-Dockerfile used to generate jforissier/optee_os_ci on hub.docker.com.
-This image is used by the OP-TEE OS Continuous Integration (CI) script:
-https://github.com/OP-TEE/optee_os/blob/master/.azure-pipelines.yml
+Dockerfile used to generate xentroops/optee_os_ci on hub.docker.com.
+
+It is based on jforissier/optee_os_ci, but is tailored for testing
+with Zephyr instead of Linux.
+

--- a/get_optee.sh
+++ b/get_optee.sh
@@ -3,8 +3,8 @@
 # 1. Clone OP-TEE development environment for the specified platform
 # 2. Download the cross-compile toolchain
 
-PLAT=${1:-default}
-ROOT_DIR=${2:-/root/optee}
+PLAT=qemu_v8
+ROOT_DIR=/root/optee
 set -e
 mkdir -p ${ROOT_DIR}
 cd ${ROOT_DIR}

--- a/get_optee_qemuv8.sh
+++ b/get_optee_qemuv8.sh
@@ -5,11 +5,11 @@
 #
 # [1] https://optee.readthedocs.io/en/latest/building/devices/qemu.html#qemu-v8
 
-ROOT_DIR=${1:-/root/optee_repo_qemu_v8}
+ROOT_DIR=/root/optee_repo_qemu_v8
 set -e
 mkdir -p ${ROOT_DIR}
 cd ${ROOT_DIR}
-repo init -u https://github.com/OP-TEE/manifest.git -m qemu_v8.xml
+repo init -u https://github.com/xen-troops/optee_manifest.git -m qemu_v8.xml -b zephyr-optee
 repo sync -j20
 cd ${ROOT_DIR}/build
 make -j2 toolchains && rm -f ${ROOT_DIR}/toolchains/gcc*.tar.xz

--- a/get_zephyr.sh
+++ b/get_zephyr.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# 1. Get zephyr test app
+# 2. Build id
+
+ROOT_DIR=/root/optee_repo_qemu_v8
+
+set -e
+mkdir -p ${ROOT_DIR}
+cd ${ROOT_DIR}
+
+west init -m https://github.com/xen-troops/zephyr-optee-test.git zephyr-optee
+cd zephyr-optee
+west update
+


### PR DESCRIPTION
We at EPAM System want to test Zephyr OP-TEE client, so we need a similar container that Linaro/OP-TEE use for own CI tests.

This is a fork of jforissier:optee_os_ci that was altered to support Zephyr builds.